### PR TITLE
Feature/208 continuation token

### DIFF
--- a/test/AzureDevOps.Scanner.Unittest/ClientTest.HelperClasses.cs
+++ b/test/AzureDevOps.Scanner.Unittest/ClientTest.HelperClasses.cs
@@ -163,7 +163,7 @@ namespace AzureDevOps.Scanner.Unittest
             Content = new StringContent("{\"count\":0,\"value\":[]}"),
         };
 
-        private HttpResponseMessage NoContentResponse => new HttpResponseMessage
+        private static HttpResponseMessage NoContentResponse => new HttpResponseMessage
         {
             StatusCode = HttpStatusCode.NoContent,
             Content = new StringContent(string.Empty),
@@ -387,7 +387,7 @@ namespace AzureDevOps.Scanner.Unittest
                 mh => mh.Send(
                     It.Is<HttpRequestMessage>(
                         req => req.RequestUri.ToString() == $"{ExpectedUrl}/{ExpectedCollection}/_apis/projects")))
-                .Returns(this.NoContentResponse);
+                .Returns(NoContentResponse);
         }
 
         private void HttpMockFailProject()


### PR DESCRIPTION
Use continuation token when present, to make sure all entries are collected and not just the automated max of a single REST call